### PR TITLE
Simplify usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,69 +35,29 @@ npm run example:android
 
 ```js
 import FindLocalDevices from 'react-native-find-local-devices';
-import { DeviceEventEmitter } from 'react-native';
 
-// Don't forget to call DeviceEventEmitter.removeAllListeners() when discovering isn't running.
-// WARNING: DeviceEventEmitter.removeAllListeners will remove all of your listeners. 
-// See the example folder. There is an advanced example how you can create 
-// and remove listeners independent of any other listeners.
-// MAIN BEHAVIOUR: 
-// ...
-  DeviceEventEmitter.addListener('NEW_DEVICE_FOUND', (device) => {
-    console.log(`NEW DEVICE FOUND: ${device.ipAddress}:${device.port}`);
-    // This listener will be activated at the moment when the device has been found.
-    // FORMAT: {ipAddress: "192.168.1.66", port: 70}
-  });
-
-  DeviceEventEmitter.addListener('RESULTS', (devices) => {
-    // ALL OF RESULTS when discovering has been finished.
-    // FORMAT: [{ipAddress: "192.168.1.66", port: 70}, {ipAddress: "192.168.1.69", port: 85}]
-  });
-
-  DeviceEventEmitter.addListener('CHECK', (device) => {
-    // This listener will be activated in that moment when package checking a device.
-    // FORMAT: {ipAddress: "192.168.1.65", port: 70}
-  });
-
-  DeviceEventEmitter.addListener('NO_DEVICES', () => {
-    // This listener will be activated at the end of discovering.
-  });
-
-  DeviceEventEmitter.addListener('NO_PORTS', () => {
-    // This listener will be activated if you don't pass any ports to the package.
-  });
-
-  DeviceEventEmitter.addListener('CONNECTION_ERROR', (error) => {
-    // Handle error messages for each socket connection
-    // console.log(error.message);
-  });
-
-  // Getting local devices which have active socket server on the following ports:
-  FindLocalDevices.getLocalDevices({
-    ports: [70, 85, 1200],
-    timeout: 40
-  });
-
+let scanner = new FindLocalDevices({
+  ports: [8000],
+  onDeviceFound: (device) => {
+    consoe.log('Found device!', device);
+  },
+  onResults: (devices) => {
+    console.log('Finished scanning', devices);
+  },
+  onCheck: (device) => {
+    console.log('Checking IP: ', device.ipAddress);
+  },
+  onFinished: () => {
+    console.log("Done!");
+  },
+  onError: (device) => {
+    // Called when no service found
+    console.log("Nothing found", device);
+  }
+})
   // When the discovering is running, you can cancel that with the following function:
-  FindLocalDevices.cancelDiscovering();
+FindLocalDevices.stop();
 // ...
-```
-
-<h3>Create a listener and remove it</h3>
-
-```js
-  // ...
-  const newDeviceFoundSubscription = DeviceEventEmitter.addListener(
-    NEW_DEVICE_FOUND,
-    (device) => {
-      if (device.ipAddress && device.port) {
-        console.log(device);
-      }
-    }
-  );
-  // ...
-  if(newDeviceFoundSubscription) newDeviceFoundSubscription.remove();
-  // ...
 ```
 
 <h2>Contributing</h2>

--- a/README.md
+++ b/README.md
@@ -13,9 +13,10 @@
 <p>You've to add a timeout and an array of ports as parameters. The package will try to create a connection with those ports and return the ip adresses which have successful connection.</p>
 <p>See the example: <a href="https://github.com/RichardRNStudio/react-native-find-local-devices/tree/main/example">https://github.com/RichardRNStudio/react-native-find-local-devices/tree/main/example</a></p>
 <p>NOTICE: It doesn't work with IOS yet. If you can help me in this case please contact me on the following email: info@rnstudio.hu</p>
-<p><i>This package has been written for the PC Controller react-native application as a submodule.</i></p>
-  <a href="https://pccontroller.rnstudio.hu">Visit the PC Controller website</a>
+<p>
+<i>This package has been written for the PC Controller react-native application as a submodule.</i>
 </p>
+<p><a href="https://pccontroller.rnstudio.hu">Visit the PC Controller website</a></p>
 </blockquote>
 
 <h2>Installation</h2>
@@ -34,9 +35,9 @@ npm run example:android
 <h2>Usage</h2>
 
 ```js
-import FindLocalDevices from 'react-native-find-local-devices';
+import PortScanner from 'react-native-find-local-devices';
 
-let scanner = new FindLocalDevices({
+const scanner = new PortScanner({
   ports: [8000],
   onDeviceFound: (device) => {
     consoe.log('Found device!', device);
@@ -56,7 +57,7 @@ let scanner = new FindLocalDevices({
   }
 })
   // When the discovering is running, you can cancel that with the following function:
-FindLocalDevices.stop();
+scanner.stop();
 // ...
 ```
 

--- a/android/src/main/java/com/reactnativefindlocaldevices/FindLocalDevicesModule.java
+++ b/android/src/main/java/com/reactnativefindlocaldevices/FindLocalDevicesModule.java
@@ -152,10 +152,10 @@ public class FindLocalDevicesModule extends ReactContextBaseJavaModule {
   }
 
   private void sendMapEvent(String eventName, WritableMap params) {
-    reactContext.getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter.class).emit(eventName, params);
+    reactContext.getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter.class).emit("FLD_"+eventName, params);
   }
 
   private void sendArrayEvent(String eventName, WritableArray params) {
-    reactContext.getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter.class).emit(eventName, params);
+    reactContext.getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter.class).emit("FLD_"+eventName, params);
   }
 }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,5 +1,86 @@
-import { NativeModules } from 'react-native';
+import {NativeModules, DeviceEventEmitter} from 'react-native';
+const {FindLocalDevices} = NativeModules;
 
-const { FindLocalDevices } = NativeModules;
+class PortScan {
 
-export default FindLocalDevices;
+  _listeners: Array<any> = [];
+
+  constructor({
+            ports = [],
+            timeout = 40,
+            onDeviceFound,
+            onResults,
+            onCheck,
+            onFinished,
+            onError
+          }){
+
+    this._listeners = [];
+
+    if (!ports.length) {
+      throw new Error("Must include at least 1 port to scan");
+    }
+
+    if (onDeviceFound) {
+      this._listeners.push(
+        DeviceEventEmitter.addListener('FLD_NEW_DEVICE_FOUND', (device) => {
+          // This listener will be activated at the moment when the device has been found.
+          // FORMAT: {ipAddress: "192.168.1.66", port: 70}
+          onDeviceFound(device);
+        })
+      );
+    }
+
+    if (onResults) {
+      this._listeners.push(
+        DeviceEventEmitter.addListener('FLD_RESULTS', (devices) => {
+          // ALL OF RESULTS when discovering has been finished.
+          // FORMAT: [{ipAddress: "192.168.1.66", port: 70}, {ipAddress: "192.168.1.69", port: 85}]
+          onResults(devices);
+        })
+      );
+    }
+
+    if(onCheck) {
+      this._listeners.push(
+      DeviceEventEmitter.addListener('FLD_CHECK', (device) => {
+        // This listener will be activated in that moment when package checking a device.
+        // FORMAT: {ipAddress: "192.168.1.65", port: 70}
+        onCheck(device);
+      }));
+    }
+
+    this._listeners.push(
+      DeviceEventEmitter.addListener('FLD_NO_DEVICES', () => {
+        // This listener will be activated at the end of discovering.
+        this._listeners.forEach(l => l.remove());
+        if(onFinished) onFinished();
+      })
+    )
+
+    if(onError){
+      this._listeners.push(
+        DeviceEventEmitter.addListener('FLD_CONNECTION_ERROR', (error) => {
+        // Handle error messages for each socket connection
+          onError(error);
+        })
+      );
+    }
+
+    FindLocalDevices.getLocalDevices({
+      ports,
+      timeout
+    });
+  }
+
+  stop = () => {
+    FindLocalDevices.cancelDiscovering();
+    this._listeners.forEach(l => l.remove());
+  }
+}
+
+export default PortScan;
+
+
+
+

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -5,6 +5,9 @@ class PortScan {
 
   _listeners: Array<any> = [];
 
+  static cancelDiscovering = FindLocalDevices.cancelDiscovering;
+  static getLocalDevices = FindLocalDevices.getLocalDevices;
+
   constructor({
             ports = [],
             timeout = 40,


### PR DESCRIPTION
Simplify usage of the library and remove the requirement to import `DeviceEventEmitter` and manually manage your listeners.
Also maintains backwards compatibility.

- Added prefix to help prevent namespace collisions in DeviceEventEmitter